### PR TITLE
camelCase -> kebab-case for URL

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,11 +22,11 @@ const App = () => (
   <OuterLayout>
     <CssBaseline />
     <Route exact path="/" component={Home} />
-    <Route path="/SearchResultView/:searchWord" component={SearchResult} />
-    <Route path="/VideoPlayerView/:playlist/:id" component={VideoPlayer} />
-    <Route path="/Settings" component={Settings} />
-    <Route path="/About" component={About} />
-    <Route path="/Playlists" component={Playlists} />
+    <Route path="/search-result/:searchWord" component={SearchResult} />
+    <Route path="/videoplayer/:playlist/:id" component={VideoPlayer} />
+    <Route path="/settings" component={Settings} />
+    <Route path="/about" component={About} />
+    <Route path="/playlists" component={Playlists} />
   </OuterLayout>
 )
 

--- a/src/components/Drawer/DrawerItems.js
+++ b/src/components/Drawer/DrawerItems.js
@@ -13,10 +13,10 @@ const DrawerItems = () => (
     <List>
       {[
         ["/", "Dashboard", <DashboardIcon />],
-        ["/Playlists", "Playlists", <PlaylistIcon />],
+        ["/playlists", "Playlists", <PlaylistIcon />],
         //["/Channels", "Channels", <ChannelIcon />],
-        ["/Settings", "Settings", <SettingsIcon />],
-        ["/About", "About", <FavBorderIcon />],
+        ["/settings", "Settings", <SettingsIcon />],
+        ["/about", "About", <FavBorderIcon />],
       ].map(item => (
         <DrawerItem key={shortid.generate()} link={item[0]} name={item[1]}>
           {item[2]}

--- a/src/components/SearchResult/SearchResultCard.js
+++ b/src/components/SearchResult/SearchResultCard.js
@@ -44,7 +44,7 @@ class SearchResultCard extends React.Component {
               onClick={() => {
                 history.push({
                   state: { video: { title, author, img, description, vId } },
-                  pathname: `/videoPlayerView/Default/${vId}`,
+                  pathname: `/videoplayer/Default/${vId}`,
                 })
               }}
               className="searchResultCardInnerButton"

--- a/src/components/TopNav/TopNav.js
+++ b/src/components/TopNav/TopNav.js
@@ -54,7 +54,7 @@ const TopNav = ({
             onSearchResults={results => onSearchResults(results)}
             onSearchTrigger={searchWord => {
               onSearchTrigger(searchWord)
-              history.push(`/searchResultView/${searchWord}`)
+              history.push(`/search-result/${searchWord}`)
             }}
           />
         </Toolbar>


### PR DESCRIPTION

* closes #25 
* discarded redundant wordings like **view** in the URL (i.e. `searchResultView` -> `search-result`). 