### PR TITLE
Delete video stats after 24 hours and start again

### DIFF
--- a/src/modules/isMoreThanOneDay.js
+++ b/src/modules/isMoreThanOneDay.js
@@ -1,0 +1,9 @@
+// startDate is a stringified date thru toString
+const isMoreThanOneDay = startDate => {
+  const oneDayInMillisecs = 60 * 60 * 24 * 1000
+  return (
+    new Date().getTime() - new Date(startDate).getTime() > oneDayInMillisecs
+  )
+}
+
+export default isMoreThanOneDay

--- a/src/reducers/videoStatsTransforms.js
+++ b/src/reducers/videoStatsTransforms.js
@@ -1,0 +1,26 @@
+import { createTransform } from "redux-persist"
+import isMoreThanOneDay from "../modules/isMoreThanOneDay"
+const { Timer } = require("easytimer.js")
+
+const transforms = createTransform(
+  // transform state on its way to being serialized and persisted.
+  (inboundState, key) => {},
+  // transform state being rehydrated
+  (outboundState, key) => {
+    const { startDate } = outboundState
+    const transformed = isMoreThanOneDay(startDate)
+      ? {
+          timer: new Timer(),
+          time: 0,
+          videoCount: 0,
+          startDate: new Date().toString(),
+        }
+      : {
+          ...outboundState,
+        }
+    return transformed
+  },
+  { whitelist: [] }
+)
+
+export default transforms


### PR DESCRIPTION
* Until now, Youtube Lite did not support deletion of data after 24 hours (as displayed in the index page), but now it can. 